### PR TITLE
Do not avoid using Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,6 @@ data class Person(val name: String)
 
 ### Enum Classes
 
-**TODO: UPDATE FOR KOTLIN** *(This is java-only and may not be true with Kotlin)*
-
-Enum classes should be avoided where possible, due to a large memory overhead. Static constants are preferred. See http://developer.android.com/training/articles/memory.html#Overhead for further details.
-
 Enum classes without methods may be formatted without line-breaks, as follows:
 
 ```kotlin


### PR DESCRIPTION
Hello,
I propose to remove this bad advice to avoid Enums because

- it is *obsolete*: Android now implements enums efficiently
- the advice was only meant for the **Android Framework**, not for Android apps which is what we care about
- it was always a **bad advice** anyway for apps developers. Static ints are not a good replacment for Enums and adding ugly annotations was not a good work-around a problem that should never have existed in the first place.

Enums are good and people should use them.