### PR TITLE
Remove paragraph on override

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,25 +377,6 @@ when (anInput) {
 }
 ```
 
-## Annotations
-
-Standard annotations should be used - in particular `override`. This should appear on the same line as the function declaration.
-
-__BAD:__
-
-```kotlin
-fun onCreate(savedInstanceState: Bundle?) {
-  super.onCreate(savedInstanceState);
-}
-```
-
-__GOOD:__
-
-```kotlin
-override fun onCreate(savedInstanceState: Bundle?) {
-  super.onCreate(savedInstanceState);
-}
-```
 
 ## Types 
 


### PR DESCRIPTION
There is no point in telling people to use the override annotation.

Unlike in Java, the Kotlin compiler simply won't let you compile your code if it doesn't have the override annotation.

So this rule is overriden by the general rule 

> Your code should compile